### PR TITLE
Added a sniff to validate return above throws

### DIFF
--- a/Superbrave/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Superbrave/Sniffs/Commenting/FunctionCommentSniff.php
@@ -43,7 +43,6 @@ class FunctionCommentSniff extends \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commen
      *
      * @param File $phpcsFile    The file being scanned.
      * @param int  $stackPtr     The position of the current token in the stack passed in $tokens.
-     * @param int  $commentStart The position in the stack where the comment started.
      *
      * @return void
      */

--- a/Superbrave/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Superbrave/Sniffs/Commenting/FunctionCommentSniff.php
@@ -25,8 +25,8 @@ class FunctionCommentSniff extends \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commen
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
      *
      * @return void
      */

--- a/Superbrave/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Superbrave/Sniffs/Commenting/FunctionCommentSniff.php
@@ -53,9 +53,7 @@ class FunctionCommentSniff extends \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commen
         }
 
         // Fetches the full function docblock
-        $start    = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
-        $end      = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
-        $docblock = $phpcsFile->getTokensAsString($start, ($end - $start));
+        $docblock = $this->getDocBlock($phpcsFile, $stackPtr);
 
         // Fetches tag locations
         $return_pos = strpos($docblock, '@return');
@@ -119,12 +117,23 @@ class FunctionCommentSniff extends \PHP_CodeSniffer\Standards\PEAR\Sniffs\Commen
      */
     protected function hasInheritDoc(File $phpcsFile, $stackPtr)
     {
-        // Fetches the full function docblock
-        $start    = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
-        $end      = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
-        $docblock = $phpcsFile->getTokensAsString($start, ($end - $start));
-
         // Returns true when {@inheritdoc} exists somewhere in the docblock, otherwise false
-        return preg_match('#{@inheritdoc}#i', $docblock) === 1;
+        return preg_match('#{@inheritdoc}#i', $this->getDocBlock($phpcsFile, $stackPtr)) === 1;
+    }
+
+    /**
+     * Fetches the docblock as string
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token in the stack passed in $tokens.
+     *
+     * @return string
+     */
+    protected function getDocBlock(File $phpcsFile, $stackPtr)
+    {
+        // Fetches the full function docblock
+        $start = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr - 1);
+        $end   = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $start);
+        return $phpcsFile->getTokensAsString($start, ($end - $start));
     }
 }


### PR DESCRIPTION
As discussed, we want to have throws under return tags.

I've added a sniff to validate on this.